### PR TITLE
fix for ampersands in description.

### DIFF
--- a/src/Roumen/Feed/Feed.php
+++ b/src/Roumen/Feed/Feed.php
@@ -144,6 +144,9 @@ class Feed
             foreach($this->items as $k => $v)
             {
                 $this->items[$k]['description'] = html_entity_decode(strip_tags($this->items[$k]['description']));
+                // escaping & in description, based on http://stackoverflow.com/questions/1328538/how-do-i-escape-ampersands-in-xml
+                $this->items[$k]['description'] = str_replace('&', '&amp;amp;', $this->items[$k]['description']);
+            
                 $this->items[$k]['title'] = html_entity_decode(strip_tags($this->items[$k]['title']));
                 $this->items[$k]['pubdate'] = $this->formatDate($this->items[$k]['pubdate'], "rss");
             }


### PR DESCRIPTION
An ampersand (&) in the description causes the rss-feed to be invalid.
Simple str_replace to escape them, based on http://stackoverflow.com/questions/1328538/how-do-i-escape-ampersands-in-xml
