### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/php-feed/security/code-scanning/1](https://github.com/RumenDamyanov/php-feed/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/ci.yml`. The block should be placed at the root level (above `jobs:`) to apply to all jobs, unless a job requires different permissions. For this workflow, the minimal required permission is likely `contents: read`, as the workflow checks out code and runs tests, but does not appear to need write access to the repository. If any step (such as uploading coverage) requires additional permissions, you can add them as needed. The best fix is to add the following block after the workflow `name` and before `on:`:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
